### PR TITLE
feat: display "since QX YYYY" for ongoing projects without end date

### DIFF
--- a/cms/src/globals/Labels.ts
+++ b/cms/src/globals/Labels.ts
@@ -38,6 +38,7 @@ const Labels: GlobalConfig = {
         labelField('navigate-to-section'),
         labelField('open-menu'),
         labelField('close-menu'),
+        labelField('since'),
       ],
     },
     {

--- a/web/src/components/ProjectDate.astro
+++ b/web/src/components/ProjectDate.astro
@@ -1,5 +1,6 @@
 ---
 import { dateStringToQuarter } from '@/utils/dateToQuarter'
+import { globalState } from '@/globalState'
 
 type Props = {
   startDate: string
@@ -8,17 +9,25 @@ type Props = {
 }
 
 const { startDate, endDate, class: className } = Astro.props
+const { labels } = globalState
 ---
 
 <p class:list={[className, 'text-slate-500']}>
-  <span>{dateStringToQuarter(startDate)}</span>
-
   {
-    endDate && dateStringToQuarter(endDate) !== dateStringToQuarter(startDate) && (
+    endDate ? (
       <>
-        <span class="font-semibold"> - </span>
-        <span>{dateStringToQuarter(endDate)}</span>
+        <span>{dateStringToQuarter(startDate)}</span>
+        {
+          dateStringToQuarter(endDate) !== dateStringToQuarter(startDate) && (
+            <>
+              <span class="font-semibold"> - </span>
+              <span>{dateStringToQuarter(endDate)}</span>
+            </>
+          )
+        }
       </>
+    ) : (
+      <span>{labels.global.since} {dateStringToQuarter(startDate)}</span>
     )
   }
 </p>


### PR DESCRIPTION
- Add "'since" label to CMS labels global for translation support
- Update ProjectDate component to show "since QX YYYY" when no end date exists
- Preserve existing behavior for projects with end dates

Closes #4