### PR TITLE
fix(cms): mark @resvg/resvg-js as serverExternalPackages

### DIFF
--- a/cms/next.config.ts
+++ b/cms/next.config.ts
@@ -12,6 +12,10 @@ const nextConfig: NextConfig = {
       source: '/',
     },
   ],
+  // `@resvg/resvg-js` loads a platform-specific `.node` native binding via its
+  // `js-binding.js` shim, which Turbopack refuses to inline into an ESM chunk.
+  // Listing it here keeps it as a runtime `require` in the serverless function.
+  serverExternalPackages: ['@resvg/resvg-js'],
 }
 
 export default withPayload(nextConfig, { devBundleServerPackages: false })


### PR DESCRIPTION
## Summary

The last deploy failed with:

```
./node_modules/.pnpm/@resvg+resvg-js@2.6.2/node_modules/@resvg/resvg-js/js-binding.js
non-ecmascript placeable asset
asset is not placeable in ESM chunks, so it doesn't have a module id
```

Turbopack tries to inline `@resvg/resvg-js`'s `js-binding.js`, which loads a platform-specific `.node` native binding at runtime. Native bindings can't live inside an ESM bundle.

Fix: add `@resvg/resvg-js` to Next.js `serverExternalPackages`, which tells the bundler to leave it as a runtime `require` in the serverless function (same pattern Next uses for `sharp` internally).

## Test plan

- [x] `pnpm lint` passes
- [x] `npx tsc --noEmit` passes
- [x] `pnpm build` in `cms` completes locally on Next 16.2.2 / Turbopack (was failing before this change)
- [ ] Vercel deploy succeeds

https://claude.ai/code/session_01TiBZD7EMkBmiPCw4qUQdEo