### PR TITLE
fix(cms): don't truncate thumbnail titles that would fit

### DIFF
--- a/cms/src/endpoints/generateThumbnail.ts
+++ b/cms/src/endpoints/generateThumbnail.ts
@@ -106,25 +106,38 @@ function escapeXml(str: string): string {
 
 function wrapText(text: string, maxCharsPerLine: number, maxLines: number): string[] {
   const words = text.trim().split(/\s+/)
-  const lines: string[] = []
+  const allLines: string[] = []
   let current = ''
   for (const word of words) {
     const trial = current ? `${current} ${word}` : word
     if (trial.length > maxCharsPerLine && current) {
-      lines.push(current)
+      allLines.push(current)
       current = word
-      if (lines.length === maxLines - 1) break
     } else {
       current = trial
     }
   }
-  if (current && lines.length < maxLines) lines.push(current)
-  // If we truncated, append ellipsis to last line.
-  const joined = lines.join(' ')
-  if (joined.length < text.length) {
-    lines[lines.length - 1] = `${lines[lines.length - 1]!.replace(/[.,;:!?]+$/, '')}…`
+  if (current) allLines.push(current)
+
+  if (allLines.length <= maxLines) return allLines
+
+  // Title is longer than maxLines — keep the first (maxLines - 1) lines and
+  // fit as many of the remaining words as possible on the last line, followed
+  // by an ellipsis.
+  const result = allLines.slice(0, maxLines - 1)
+  const remainingWords = allLines
+    .slice(maxLines - 1)
+    .join(' ')
+    .split(/\s+/)
+  const ellipsisBudget = 1 // leave room for the trailing "…"
+  let last = ''
+  for (const word of remainingWords) {
+    const trial = last ? `${last} ${word}` : word
+    if (trial.length + ellipsisBudget > maxCharsPerLine && last) break
+    last = trial
   }
-  return lines
+  result.push(`${last.replace(/[.,;:!?]+$/, '')}…`)
+  return result
 }
 
 // Scaled-down inline of /web/public/icon.svg — the brand mark.


### PR DESCRIPTION
## Summary

`wrapText` was `break`ing out of the word loop the moment it pushed the `(maxLines - 1)`th line, which dropped every word after the one that caused the overflow. The trailing-ellipsis check then fired because the dropped words made `joined.length < text.length`.

Net effect: a title like **"Building Scalable AI Content Workflows with Modern Agentic Tooling"** — which naturally fits in three 26-char lines —  was being rendered as `["Building Scalable AI", "Content Workflows with", "Modern…"]`, dropping "Agentic Tooling".

Rewrite to wrap all lines first, only truncate if the result genuinely exceeds `maxLines`, and when truncating, pack as many remaining words as possible onto the last line before the ellipsis.

## Test plan

- [x] `pnpm lint` in `cms`
- [x] `npx tsc --noEmit` in `cms`
- [x] Verified wrap behavior with a small Node harness across 8 cases including the bug reproducer, simple titles, long truncated titles, and subtitles. Before: the bug case wraps to 3 lines with "Modern…". After: all three lines render in full, no ellipsis.
- [ ] Deploy and call `POST /api/generate-thumbnail` with the previously-truncated title to visually confirm all three lines render.

https://claude.ai/code/session_01TiBZD7EMkBmiPCw4qUQdEo