### PR TITLE
feat(cms): add GPT-5 mini option to chat agent plugin

### DIFF
--- a/cms/package.json
+++ b/cms/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.71",
+    "@ai-sdk/openai": "^3.0.53",
     "@jhb.software/payload-admin-search": "^0.2.1",
     "@jhb.software/payload-alt-text-plugin": "^0.4.4",
     "@jhb.software/payload-chat-agent": "0.1.0-beta.3",

--- a/cms/src/payload.config.ts
+++ b/cms/src/payload.config.ts
@@ -1,4 +1,5 @@
 import { createAnthropic } from '@ai-sdk/anthropic'
+import { createOpenAI } from '@ai-sdk/openai'
 import { adminSearchPlugin } from '@jhb.software/payload-admin-search'
 import {
   openAIResolver as altTextOpenAIResolver,
@@ -459,10 +460,14 @@ export default buildConfig({
       availableModels: [
         { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
         { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+        { id: 'gpt-5-mini', label: 'GPT-5 mini' },
       ],
       budget: chatBudget,
       defaultModel: 'claude-haiku-4-5',
-      model: (id) => createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })(id),
+      model: (id) =>
+        id.startsWith('gpt-')
+          ? createOpenAI({ apiKey: process.env.OPENAI_API_KEY })(id)
+          : createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })(id),
     }),
   ],
 })

--- a/cms/src/payload.config.ts
+++ b/cms/src/payload.config.ts
@@ -73,6 +73,9 @@ const { budget: chatBudget, collection: chatTokenUsageCollection } = createPaylo
   scope: 'user',
 })
 
+const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY })
+const anthropicClient = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+
 export const collections: CollectionConfig[] = [
   // Pages Collections
   Pages,
@@ -536,10 +539,7 @@ export default buildConfig({
       ],
       budget: chatBudget,
       defaultModel: 'claude-haiku-4-5',
-      model: (id) =>
-        id.startsWith('gpt-')
-          ? createOpenAI({ apiKey: process.env.OPENAI_API_KEY })(id)
-          : createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })(id),
+      model: (id) => (id.startsWith('gpt-') ? openai(id) : anthropicClient(id)),
       tools: ({ defaultTools }) => ({
         ...defaultTools,
         webFetch: anthropic.tools.webFetch_20250910({ maxUses: 5 }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: ^3.0.71
         version: 3.0.71(zod@4.1.12)
+      '@ai-sdk/openai':
+        specifier: ^3.0.53
+        version: 3.0.53(zod@4.1.12)
       '@jhb.software/payload-admin-search':
         specifier: ^0.2.1
         version: 0.2.1(@payloadcms/translations@3.83.0)(@payloadcms/ui@3.83.0(@types/react@19.2.4)(monaco-editor@0.52.2)(next@16.2.2(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4))(payload@3.83.0(graphql@16.12.0)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(next@16.2.2(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4))(payload@3.83.0(graphql@16.12.0)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -258,6 +261,12 @@ packages:
 
   '@ai-sdk/gateway@3.0.104':
     resolution: {integrity: sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@3.0.53':
+    resolution: {integrity: sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -6690,6 +6699,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
       '@vercel/oidc': 3.2.0
       zod: 3.25.76
+
+  '@ai-sdk/openai@3.0.53(zod@4.1.12)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.1.12)
+      zod: 4.1.12
 
   '@ai-sdk/provider-utils@4.0.23(zod@3.25.76)':
     dependencies:


### PR DESCRIPTION
Enable multi-provider model selection in the chat agent by routing model
IDs prefixed with `gpt-` through @ai-sdk/openai while keeping Claude
models on @ai-sdk/anthropic.

## Caveat

The `tools` block (web search / web fetch) uses Anthropic-native server tools,
and the current plugin version does not expose the active model ID to the
`tools` callback, so the same tool definitions are sent regardless of provider.
If a user selects `gpt-5-mini`, those Anthropic tools will not work on the
OpenAI provider. This will be fixed in a future plugin version.

https://claude.ai/code/session_01ViTM3RT8naLc4dd7L1ufPp