### PR TITLE
feat(cms): cleaner thumbnail filenames and draft-aware article linking

### DIFF
--- a/cms/.gitignore
+++ b/cms/.gitignore
@@ -4,3 +4,6 @@
 
 # Environment
 .env*.local
+
+# TypeScript incremental build cache
+*.tsbuildinfo

--- a/cms/src/endpoints/generateThumbnail.ts
+++ b/cms/src/endpoints/generateThumbnail.ts
@@ -339,6 +339,31 @@ export async function generateThumbnail(req: PayloadRequest) {
   const pattern: BackgroundPattern = body.background?.pattern === 'gradient' ? 'gradient' : 'blobs'
   const preset = resolvePreset(body.background)
 
+  // Resolve the target article before rendering so bad IDs fail fast with 404
+  // and don't leave an orphan thumbnail behind. `_status` drives the draft-aware
+  // update further down.
+  let articleStatus: 'draft' | 'published' | undefined
+  if (body.articleId) {
+    try {
+      const existing = await req.payload.findByID({
+        collection: 'articles',
+        depth: 0,
+        draft: true,
+        id: body.articleId,
+        req,
+        select: { _status: true },
+      })
+      articleStatus = existing._status ?? 'published'
+    } catch (error) {
+      req.payload.logger.warn({
+        articleId: body.articleId,
+        err: error,
+        msg: 'Article lookup failed — treating as not found',
+      })
+      return new Response(`Article ${body.articleId} not found`, { status: 404 })
+    }
+  }
+
   const svg = buildThumbnailSvg({ pattern, preset, subtitle, title })
 
   let buffer: Buffer
@@ -391,21 +416,12 @@ export async function generateThumbnail(req: PayloadRequest) {
 
   if (body.articleId) {
     try {
-      // Match the article's current draft/published state so we don't
-      // accidentally publish a pending draft by writing to the main table.
-      const existing = await req.payload.findByID({
-        collection: 'articles',
-        depth: 0,
-        draft: true,
-        id: body.articleId,
-        req,
-        select: { _status: true },
-      })
-
+      // Match the article's current draft/published state (resolved above)
+      // so we don't accidentally publish a pending draft.
       await req.payload.update({
         collection: 'articles',
         data: { image: image.id },
-        draft: existing._status === 'draft',
+        draft: articleStatus === 'draft',
         id: body.articleId,
         req,
       })

--- a/cms/src/endpoints/generateThumbnail.ts
+++ b/cms/src/endpoints/generateThumbnail.ts
@@ -30,6 +30,11 @@ type GenerateThumbnailBody = {
   /** If provided, the new image is set as the article's thumbnail. */
   articleId?: string
   background?: BackgroundInput
+  /**
+   * Custom filename (without extension). Sanitized to `[a-z0-9-]` and clamped
+   * to 60 chars. If omitted, the filename is derived from `title`.
+   */
+  filename?: string
   /** Output format. Defaults to `webp`. */
   format?: 'png' | 'webp'
   subtitle: string
@@ -362,12 +367,15 @@ export async function generateThumbnail(req: PayloadRequest) {
     return new Response('Failed to render thumbnail', { status: 500 })
   }
 
-  const slug = title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 48)
-  const filename = `thumbnail-${slug || 'article'}-${Date.now()}.${format}`
+  const slugify = (value: string) =>
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 60)
+  const customName = typeof body.filename === 'string' ? slugify(body.filename) : ''
+  const nameStem = customName || slugify(title) || 'article'
+  const filename = `${nameStem}.${format}`
 
   const image = await req.payload.create({
     collection: 'images',
@@ -383,9 +391,20 @@ export async function generateThumbnail(req: PayloadRequest) {
 
   if (body.articleId) {
     try {
+      // Match the article's current draft/published state so we don't
+      // accidentally publish a pending draft by writing to the main table.
+      const existing = await req.payload.findByID({
+        collection: 'articles',
+        depth: 0,
+        draft: true,
+        id: body.articleId,
+        req,
+      })
+
       await req.payload.update({
         collection: 'articles',
         data: { image: image.id },
+        draft: existing._status === 'draft',
         id: body.articleId,
         req,
       })

--- a/cms/src/endpoints/generateThumbnail.ts
+++ b/cms/src/endpoints/generateThumbnail.ts
@@ -399,6 +399,7 @@ export async function generateThumbnail(req: PayloadRequest) {
         draft: true,
         id: body.articleId,
         req,
+        select: { _status: true },
       })
 
       await req.payload.update({

--- a/cms/src/payload.config.ts
+++ b/cms/src/payload.config.ts
@@ -230,7 +230,6 @@ export default buildConfig({
             subtitle: { required: true, type: 'string' },
             title: { required: true, type: 'string' },
           },
-          query: {},
           response: {
             filename: { type: 'string' },
             id: { type: 'string' },

--- a/cms/src/payload.config.ts
+++ b/cms/src/payload.config.ts
@@ -202,7 +202,7 @@ export default buildConfig({
     {
       custom: {
         description:
-          'Generate a branded 1920x1080 article thumbnail (Montserrat typeface, matching the website) with title, subtitle and the JHB logo in the bottom-left. Backgrounds come as either `blobs` (gradient with blurred accent colors) or `gradient` (plain linear gradient), with an optional film-grain noise overlay. The image is uploaded to the `images` collection and (if `articleId` is provided) set as the article`s `image`. Body: { title: string, subtitle: string, background?: { preset?: "blue"|"purple"|"dark"|"teal"|"sunset", pattern?: "blobs"|"gradient", colors?: [hex, hex], accents?: [hex, hex], noise?: boolean }, format?: "webp"|"png", articleId?: string }. Returns: { id, url, filename, linkedToArticle }.',
+          'Generate a branded 1920x1080 article thumbnail (Montserrat typeface, matching the website) with title, subtitle and the JHB logo in the bottom-left. Backgrounds come as either `blobs` (gradient with blurred accent colors) or `gradient` (plain linear gradient), with an optional film-grain noise overlay. The image is uploaded to the `images` collection and (if `articleId` is provided) set as the article`s `image`. Body: { title: string, subtitle: string, background?: { preset?: "blue"|"purple"|"dark"|"teal"|"sunset", pattern?: "blobs"|"gradient", colors?: [hex, hex], accents?: [hex, hex], noise?: boolean }, format?: "webp"|"png", filename?: string, articleId?: string }. `filename` is optional; when omitted the filename is derived from `title` (sanitized to [a-z0-9-], max 60 chars). Returns: { id, url, filename, linkedToArticle }.',
       },
       handler: generateThumbnail,
       method: 'post',


### PR DESCRIPTION
## Summary
Enhanced the thumbnail generation endpoint to support custom filenames and improved article lookup validation to prevent orphaned thumbnails.

## Key Changes
- **Custom filename support**: Added optional `filename` parameter to `GenerateThumbnailBody` that accepts custom filenames (sanitized to `[a-z0-9-]` and clamped to 60 characters). Falls back to title-derived filename if omitted.
- **Early article validation**: Implemented upfront article ID lookup before rendering to fail fast with 404 errors and prevent leaving orphan thumbnails when articles don't exist.
- **Draft-aware updates**: Article thumbnail updates now respect the article's current draft/published state, preventing accidental publication of pending drafts.
- **Filename generation refactor**: Extracted slugification logic into a reusable function and simplified filename generation to use a consistent stem-based approach.
- **Schema updates**: Added `filename` field to the OpenAPI schema in `payload.config.ts`.
- **Build cache**: Added `*.tsbuildinfo` to `.gitignore` for TypeScript incremental builds.

## Implementation Details
- Article lookup uses `findByID` with `draft: true` to check both draft and published states before rendering
- Filename sanitization uses the same pattern as title slugification (lowercase, alphanumeric + hyphens, trim edges, max 60 chars)
- The `draft` parameter in the article update is now explicitly set based on the resolved article status to maintain consistency

https://claude.ai/code/session_01XBrQNmUnDYVP1tGEFXdNf2